### PR TITLE
Added ReverseGeocoding for Nominatim

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The Nominatim response is converted to the GraphHopper response layout.
 
 ## Query Interface
 
+### Geocoding (forward)
+
 The service should be queried like:
 ```
 https://graphhopper.com/api/1/search?q=berlin[&NOMINATIM_PARAMETER]&key=[YOUR_KEY]
@@ -25,6 +27,18 @@ http://nominatim.openstreetmap.org/search/Unter%20den%20Linden?city=berlin&forma
 ```
 
 The `format=json` and `addressdetails=1` are added to every request.
+
+### Reverse Geocoding
+
+A sample request would be:
+```
+https://graphhopper.com/api/1/geocode?point=52.5487429714954,-1.81602098644987&reverse=true&key=[YOUR_KEY]
+```
+
+The request would be wrapped to:
+```
+http://nominatim.openstreetmap.org/reverse?format=json&lat=52.5487429714954&lon=-1.81602098644987&zoom=18&addressdetails=1
+```
 
 ## Nominatim Response
 

--- a/converter.yml
+++ b/converter.yml
@@ -1,4 +1,6 @@
+#TODO it might be better to only specify the base url like http://nominatim.openstreetmap.org/?
 nominatimUrl: http://nominatim.openstreetmap.org/search/
+nominatimReverseUrl: http://nominatim.openstreetmap.org/reverse/
 nominatim: true
 nominatimEmail: 
 

--- a/converter.yml
+++ b/converter.yml
@@ -1,4 +1,3 @@
-#TODO it might be better to only specify the base url like http://nominatim.openstreetmap.org/?
 nominatimUrl: http://nominatim.openstreetmap.org/search/
 nominatimReverseUrl: http://nominatim.openstreetmap.org/reverse/
 nominatim: true

--- a/src/main/java/com/graphhopper/converter/ConverterApplication.java
+++ b/src/main/java/com/graphhopper/converter/ConverterApplication.java
@@ -42,13 +42,16 @@ public class ConverterApplication extends Application<ConverterConfiguration> {
         cfg.setTimeout(Duration.seconds(5));
         cfg.setConnectionTimeout(Duration.seconds(5));
         cfg.setConnectionRequestTimeout(Duration.seconds(5));
-        
+
         final Client client = new JerseyClientBuilder(environment).using(cfg)
                 .build(getName());
 
         if (converterConfiguration.isNominatim()) {
             final ConverterResourceNominatim resource = new ConverterResourceNominatim(
-                    converterConfiguration.getNominatimUrl(), converterConfiguration.getNominatimEmail(), client);
+                    converterConfiguration.getNominatimUrl(),
+                    converterConfiguration.getNominatimReverseUrl(),
+                    converterConfiguration.getNominatimEmail(),
+                    client);
             environment.jersey().register(resource);
         }
 

--- a/src/main/java/com/graphhopper/converter/ConverterConfiguration.java
+++ b/src/main/java/com/graphhopper/converter/ConverterConfiguration.java
@@ -15,6 +15,8 @@ public class ConverterConfiguration extends Configuration {
 
     @NotEmpty
     private String nominatimUrl = "http://nominatim.openstreetmap.org/search/";
+    @NotEmpty
+    private String nominatimReverseUrl = "http://nominatim.openstreetmap.org/reverse/";
     private String nominatimEmail = "";
     private String openCageDataUrl = "https://api.opencagedata.com/geocode/v1/json";
     private String openCageDataKey = "";
@@ -123,5 +125,13 @@ public class ConverterConfiguration extends Configuration {
     @JsonProperty(value = "ipWhiteList")
     public void setIPWhiteList(String ipWhiteList) {
         this.ipWhiteList = ipWhiteList;
+    }
+
+    public String getNominatimReverseUrl() {
+        return nominatimReverseUrl;
+    }
+
+    public void setNominatimReverseUrl(String nominatimReverseUrl) {
+        this.nominatimReverseUrl = nominatimReverseUrl;
     }
 }

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
@@ -12,6 +12,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -22,31 +23,40 @@ import java.util.List;
 public class ConverterResourceNominatim {
 
     private final String nominatimUrl;
+    private final String nominatimReverseUrl;
     private final String nominatimEmail;
     private final Client jerseyClient;
 
-    public ConverterResourceNominatim(String nominatimUrl, String nominatimEmail, Client jerseyClient) {
+    public ConverterResourceNominatim(String nominatimUrl, String nominatimReverseUrl, String nominatimEmail, Client jerseyClient) {
         this.nominatimUrl = nominatimUrl;
+        this.nominatimReverseUrl = nominatimReverseUrl;
         this.nominatimEmail = nominatimEmail;
         this.jerseyClient = jerseyClient;
     }
 
     @GET
     @Timed
-    public Response handle(@NotNull @QueryParam("q") String query,
+    public Response handle(@QueryParam("q") @DefaultValue("") String query,
                            @QueryParam("limit") @DefaultValue("5") int limit,
                            @QueryParam("locale") @DefaultValue("") String locale,
                            @QueryParam("viewbox") @DefaultValue("") String viewbox,
                            @QueryParam("viewboxlbrt") @DefaultValue("") String viewboxlbrt,
-                           @QueryParam("bounded") @DefaultValue("") String bounded
+                           @QueryParam("bounded") @DefaultValue("") String bounded,
+                           @QueryParam("reverse") @DefaultValue("false") boolean reverse,
+                           @QueryParam("point") @DefaultValue("false") String point
     ) {
         if (limit > 10) {
             limit = 10;
         }
 
-        WebTarget target = jerseyClient.
-                target(nominatimUrl).
-                queryParam("q", query).
+        WebTarget target;
+        if (reverse) {
+            target = buildReverseTarget(point);
+        } else {
+            target = buildForwardTarget(query);
+        }
+
+        target = target.
                 queryParam("limit", limit).
                 queryParam("format", "json").
                 queryParam("email", nominatimEmail).
@@ -69,8 +79,42 @@ public class ConverterResourceNominatim {
                 get();
 
         Status status = new Status(response.getStatus(), response.getStatusInfo().getReasonPhrase());
-        List<NominatimEntry> entitiesFromResponse = response.readEntity(new GenericType<List<NominatimEntry>>() {
-        });
+        List<NominatimEntry> entitiesFromResponse;
+        if (reverse) {
+            System.out.println(response);
+            entitiesFromResponse = new ArrayList<>(1);
+            entitiesFromResponse.add(0, response.readEntity(NominatimEntry.class));
+        } else {
+            entitiesFromResponse = response.readEntity(new GenericType<List<NominatimEntry>>() {
+            });
+        }
         return Converter.convertFromNominatimList(entitiesFromResponse, status);
+    }
+
+    private WebTarget buildForwardTarget(String query) {
+        if (query == null || query.isEmpty()) {
+            throw new IllegalArgumentException("The q parameter cannot be empty");
+        }
+
+        return jerseyClient.
+                target(nominatimUrl).
+                queryParam("q", query);
+    }
+
+    private WebTarget buildReverseTarget(String point) {
+        if (point == null || point.isEmpty()) {
+            throw new IllegalArgumentException("When setting reverse=true you have to pass the point parameter");
+        }
+        String[] cords = point.split(",");
+        if (cords.length != 2) {
+            throw new IllegalArgumentException("You have to pass the point in the format \"lat,lon\"");
+        }
+
+        String lat = cords[0];
+        String lon = cords[1];
+        return jerseyClient.
+                target(nominatimReverseUrl).
+                queryParam("lat", lat).
+                queryParam("lon", lon);
     }
 }

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
@@ -81,7 +81,6 @@ public class ConverterResourceNominatim {
         Status status = new Status(response.getStatus(), response.getStatusInfo().getReasonPhrase());
         List<NominatimEntry> entitiesFromResponse;
         if (reverse) {
-            System.out.println(response);
             entitiesFromResponse = new ArrayList<>(1);
             entitiesFromResponse.add(0, response.readEntity(NominatimEntry.class));
         } else {

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourceTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourceTest.java
@@ -24,7 +24,7 @@ public class ConverterResourceTest {
 
     @Test
     public void testHandleForward() {
-        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test forward client");
 
         client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
         client.property(ClientProperties.READ_TIMEOUT, 100000);
@@ -39,7 +39,7 @@ public class ConverterResourceTest {
 
     @Test
     public void testHandleReverse() {
-        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test reverse client");
 
         client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
         client.property(ClientProperties.READ_TIMEOUT, 100000);

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourceTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourceTest.java
@@ -23,7 +23,7 @@ public class ConverterResourceTest {
             new DropwizardAppRule<>(ConverterApplication.class, ResourceHelpers.resourceFilePath("converter.yml"));
 
     @Test
-    public void testHandle() {
+    public void testHandleForward() {
         Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
 
         client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
@@ -31,6 +31,21 @@ public class ConverterResourceTest {
 
         Response response = client.target(
                 String.format("http://localhost:%d/nominatim?q=berlin", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void testHandleReverse() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        Response response = client.target(
+                String.format("http://localhost:%d/nominatim?point=52.5487429714954,-1.81602098644987&reverse=true", RULE.getLocalPort()))
                 .request()
                 .get();
 


### PR DESCRIPTION
Added a simple implementation of Nominatim Reverse Geocoding. OCD is not included here. I was not sure if we should only provide the base nominatim url `http://nominatim.openstreetmap.org/` in the converter.yml.
