### PR TITLE
Added Street to GHEntry

### DIFF
--- a/src/main/java/com/graphhopper/converter/api/GHEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/GHEntry.java
@@ -19,8 +19,9 @@ public class GHEntry {
     private String country;
     private String city;
     private String state;
+    private String street;
 
-    public GHEntry(Long osmId, String type, double lat, double lng, String name, String country, String city, String state) {
+    public GHEntry(Long osmId, String type, double lat, double lng, String name, String country, String city, String state, String street) {
         this.osmId = osmId;
         this.osmType = type;
         this.point = new Point(lat, lng);
@@ -28,6 +29,7 @@ public class GHEntry {
         this.country = country;
         this.city = city;
         this.state = state;
+        this.street = street;
     }
 
     @JsonProperty
@@ -59,7 +61,7 @@ public class GHEntry {
     public String getState() {
         return state;
     }
-    
+
     @JsonProperty
     public String getCity() {
         return city;
@@ -98,6 +100,16 @@ public class GHEntry {
     @JsonProperty("osm_type")
     public void setOsmType(String type) {
         this.osmType = type;
+    }
+
+    @JsonProperty
+    public String getStreet() {
+        return street;
+    }
+
+    @JsonProperty
+    public void setStreet(String street) {
+        this.street = street;
     }
 
     public class Point {

--- a/src/main/java/com/graphhopper/converter/api/NominatimEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/NominatimEntry.java
@@ -16,6 +16,7 @@ public class NominatimEntry {
     private double lon;
 
     private String displayName;
+    private String classString;
 
     private Address address;
 
@@ -27,12 +28,37 @@ public class NominatimEntry {
         this.displayName = displayName;
 
         this.address = new Address();
-        address.setCountry(country);
-        address.setCity(city);
+        address.country = country;
+        address.city = city;
     }
 
     public NominatimEntry() {
         this.address = new Address();
+    }
+
+    public boolean isStreet() {
+        if ("highway".equals(this.classString)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns the Street name if this entry is a street, return null otherwise.
+     * We return null, since we do not serialize null properties.
+     */
+    public String getStreetNameOrNull() {
+        if (!isStreet()) {
+            return null;
+        }
+        if (this.address.road != null) {
+            return this.address.road;
+        }
+        if (this.address.pedestrian != null) {
+            return this.address.pedestrian;
+        }
+
+        throw new IllegalStateException("If entry is a street, we have to return a street for: " + this.displayName);
     }
 
     @JsonProperty("osm_id")
@@ -102,18 +128,38 @@ public class NominatimEntry {
         this.address = address;
     }
 
+    @JsonProperty("class")
+    public String getClassString() {
+        return classString;
+    }
+
+    @JsonProperty("class")
+    public void setClassString(String classString) {
+        this.classString = classString;
+    }
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     public class Address {
 
         public Address() {
         }
 
-        private String country;
-        private String city;
-        private String state;
-        private String town;
-        private String village;
-        private String hamlet;
+        @JsonProperty
+        public String country;
+        @JsonProperty
+        public String city;
+        @JsonProperty
+        public String state;
+        @JsonProperty
+        public String town;
+        @JsonProperty
+        public String village;
+        @JsonProperty
+        public String hamlet;
+        @JsonProperty("road")
+        public String road;
+        @JsonProperty("pedestrian")
+        public String pedestrian;
 
         public String getGHCity() {
             if (city != null) {
@@ -126,66 +172,6 @@ public class NominatimEntry {
                 return village;
             }
             return hamlet;
-        }
-
-        @JsonProperty
-        public String getCountry() {
-            return country;
-        }
-
-        @JsonProperty
-        public void setCountry(String country) {
-            this.country = country;
-        }
-
-        @JsonProperty
-        public String getCity() {
-            return city;
-        }
-
-        @JsonProperty
-        public void setCity(String city) {
-            this.city = city;
-        }
-
-        @JsonProperty
-        public String getVillage() {
-            return village;
-        }
-
-        @JsonProperty
-        public void setVillage(String village) {
-            this.village = village;
-        }
-
-        @JsonProperty
-        public String getHamlet() {
-            return hamlet;
-        }
-
-        @JsonProperty
-        public void setHamlet(String hamlet) {
-            this.hamlet = hamlet;
-        }
-
-        @JsonProperty
-        public String getTown() {
-            return town;
-        }
-
-        @JsonProperty
-        public void setTown(String town) {
-            this.town = town;
-        }
-
-        @JsonProperty
-        public String getState() {
-            return state;
-        }
-
-        @JsonProperty
-        public void setState(String state) {
-            this.state = state;
         }
     }
 }

--- a/src/main/java/com/graphhopper/converter/api/OpenCageDataEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/OpenCageDataEntry.java
@@ -52,10 +52,16 @@ public class OpenCageDataEntry {
         public OCDComponents() {
         }
 
+        @JsonProperty("_type")
+        public String type;
         @JsonProperty("country")
         public String country;
         @JsonProperty("country_code")
         public String countryCode;
+        @JsonProperty("road")
+        public String road;
+        @JsonProperty("pedestrian")
+        public String pedestrian;
         @JsonProperty("county")
         public String county;
         @JsonProperty("state")
@@ -93,6 +99,31 @@ public class OpenCageDataEntry {
         this.geometry.lat = lat;
         this.geometry.lng = lon;
         this.components = components;
+    }
+
+    public boolean isStreet() {
+        if ("road".equals(this.components.type)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns the Street name if this entry is a street, return null otherwise.
+     * We return null, since we do not serialize null properties.
+     */
+    public String getStreetNameOrNull() {
+        if (!isStreet()) {
+            return null;
+        }
+        if (this.components.road != null) {
+            return this.components.road;
+        }
+        if (this.components.pedestrian != null) {
+            return this.components.pedestrian;
+        }
+
+        throw new IllegalStateException("If entry is a street, we have to return a street for: "+this.formatted);
     }
 
     @JsonProperty("formatted")

--- a/src/main/java/com/graphhopper/converter/core/Converter.java
+++ b/src/main/java/com/graphhopper/converter/core/Converter.java
@@ -13,7 +13,7 @@ public class Converter {
 
     public static GHEntry convertFromNominatim(NominatimEntry response) {
         GHEntry rsp = new GHEntry(response.getOsmId(), response.getGHOsmType(), response.getLat(), response.getLon(), response.getDisplayName(),
-                response.getAddress().getCountry(), response.getAddress().getGHCity(), response.getAddress().getState());
+                response.getAddress().country, response.getAddress().getGHCity(), response.getAddress().state, response.getStreetNameOrNull());
         return rsp;
     }
 
@@ -65,7 +65,8 @@ public class Converter {
 
         GHEntry rsp = new GHEntry(osmId, type, response.getGeometry().lat, response.getGeometry().lng,
                 response.getFormatted(), response.getComponents().country, response.getComponents().getGHCity(),
-                response.getComponents().state);
+                response.getComponents().state, response.getStreetNameOrNull());
+
         return rsp;
     }
 

--- a/src/test/java/com/graphhopper/converter/core/ConverterTest.java
+++ b/src/test/java/com/graphhopper/converter/core/ConverterTest.java
@@ -37,8 +37,8 @@ public class ConverterTest {
         nominatimResponse.setDisplayName("test");
         nominatimResponse.setLat(1);
         nominatimResponse.setLon(1);
-        nominatimResponse.getAddress().setTown("townie");
-        nominatimResponse.getAddress().setCountry("gb");
+        nominatimResponse.getAddress().town = "townie";
+        nominatimResponse.getAddress().country = "gb";
         GHEntry ghResponse = Converter.convertFromNominatim(nominatimResponse);
 
         assertEquals(1L, (long) ghResponse.getOsmId());
@@ -47,5 +47,28 @@ public class ConverterTest {
         assertEquals("test", ghResponse.getName());
         assertEquals("gb", ghResponse.getCountry());
         assertEquals("townie", ghResponse.getCity());
+    }
+
+    @Test
+    public void testStreetEntry() {
+        // Build a Response
+        NominatimEntry nominatimResponse = new NominatimEntry();
+        nominatimResponse.setOsmId(1L);
+        nominatimResponse.setDisplayName("test");
+        nominatimResponse.setLat(1);
+        nominatimResponse.setLon(1);
+        nominatimResponse.setClassString("highway");
+        nominatimResponse.getAddress().town = "townie";
+        nominatimResponse.getAddress().country = "gb";
+        nominatimResponse.getAddress().pedestrian = "secret way";
+        GHEntry ghResponse = Converter.convertFromNominatim(nominatimResponse);
+
+        assertEquals(1L, (long) ghResponse.getOsmId());
+        assertEquals(1, ghResponse.getPoint().getLat(), 0.001);
+        assertEquals(1, ghResponse.getPoint().getLng(), 0.001);
+        assertEquals("test", ghResponse.getName());
+        assertEquals("gb", ghResponse.getCountry());
+        assertEquals("townie", ghResponse.getCity());
+        assertEquals("secret way", ghResponse.getStreet());
     }
 }


### PR DESCRIPTION
This PR adds a street field to GHEntry as discussed in #13 this is currently missing.

Things to watch out for in this commit:
- Nominatim uses class as a keyword, which is forbidden in Java, therefore I use classString as variable name, however I am not really happy with that, maybe we find something better?
- Bot OCDEntry and NominatimEntry contain the function `isStreet` and `getStreetNameOrNull` which is an indicator to create at least a common interface. Right now we don't need it, therefore I have not created it, but I am wondering if we should? Right now there would be no benefit, IMHO.

@karussell what do you think?
