### PR TITLE
Added OCD reverse geocoding

### DIFF
--- a/src/main/java/com/graphhopper/converter/api/NominatimEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/NominatimEntry.java
@@ -37,17 +37,14 @@ public class NominatimEntry {
     }
 
     public boolean isStreet() {
-        if ("highway".equals(this.classString)) {
-            return true;
-        }
-        return false;
+        return "highway".equals(this.classString);
     }
 
     /**
      * Returns the Street name if this entry is a street, return null otherwise.
      * We return null, since we do not serialize null properties.
      */
-    public String getStreetNameOrNull() {
+    public String getStreetName() {
         if (!isStreet()) {
             return null;
         }

--- a/src/main/java/com/graphhopper/converter/api/OpenCageDataEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/OpenCageDataEntry.java
@@ -102,17 +102,14 @@ public class OpenCageDataEntry {
     }
 
     public boolean isStreet() {
-        if ("road".equals(this.components.type)) {
-            return true;
-        }
-        return false;
+        return "road".equals(this.components.type);
     }
 
     /**
      * Returns the Street name if this entry is a street, return null otherwise.
      * We return null, since we do not serialize null properties.
      */
-    public String getStreetNameOrNull() {
+    public String getStreetName() {
         if (!isStreet()) {
             return null;
         }

--- a/src/main/java/com/graphhopper/converter/core/Converter.java
+++ b/src/main/java/com/graphhopper/converter/core/Converter.java
@@ -13,7 +13,7 @@ public class Converter {
 
     public static GHEntry convertFromNominatim(NominatimEntry response) {
         GHEntry rsp = new GHEntry(response.getOsmId(), response.getGHOsmType(), response.getLat(), response.getLon(), response.getDisplayName(),
-                response.getAddress().country, response.getAddress().getGHCity(), response.getAddress().state, response.getStreetNameOrNull());
+                response.getAddress().country, response.getAddress().getGHCity(), response.getAddress().state, response.getStreetName());
         return rsp;
     }
 
@@ -65,7 +65,7 @@ public class Converter {
 
         GHEntry rsp = new GHEntry(osmId, type, response.getGeometry().lat, response.getGeometry().lng,
                 response.getFormatted(), response.getComponents().country, response.getComponents().getGHCity(),
-                response.getComponents().state, response.getStreetNameOrNull());
+                response.getComponents().state, response.getStreetName());
 
         return rsp;
     }

--- a/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
+++ b/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
@@ -1,0 +1,30 @@
+package com.graphhopper.converter.resources;
+
+/**
+ * @author Robin Boldt
+ */
+abstract class AbstractConverterResource {
+
+    int fixLimit(int limit) {
+        if (limit > 10) {
+            return 10;
+        }
+        return limit;
+    }
+
+    void checkInvalidParameter(boolean reverse, String query, String point) {
+        if (reverse) {
+            String[] cords = point.split(",");
+            if (cords.length != 2) {
+                throw new IllegalArgumentException("You have to pass the point in the format \"lat,lon\"");
+            }
+            double lat = Double.parseDouble(cords[0]);
+            double lon = Double.parseDouble(cords[1]);
+        } else {
+            if (query.isEmpty()) {
+                throw new IllegalArgumentException("q cannot be empty");
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
@@ -5,12 +5,10 @@ import com.graphhopper.converter.api.NominatimEntry;
 import com.graphhopper.converter.api.Status;
 import com.graphhopper.converter.core.Converter;
 
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +18,7 @@ import java.util.List;
  */
 @Path("/nominatim")
 @Produces("application/json; charset=utf-8")
-public class ConverterResourceNominatim {
+public class ConverterResourceNominatim extends AbstractConverterResource {
 
     private final String nominatimUrl;
     private final String nominatimReverseUrl;
@@ -45,9 +43,8 @@ public class ConverterResourceNominatim {
                            @QueryParam("reverse") @DefaultValue("false") boolean reverse,
                            @QueryParam("point") @DefaultValue("false") String point
     ) {
-        if (limit > 10) {
-            limit = 10;
-        }
+        limit = fixLimit(limit);
+        checkInvalidParameter(reverse, query, point);
 
         WebTarget target;
         if (reverse) {
@@ -105,10 +102,6 @@ public class ConverterResourceNominatim {
             throw new IllegalArgumentException("When setting reverse=true you have to pass the point parameter");
         }
         String[] cords = point.split(",");
-        if (cords.length != 2) {
-            throw new IllegalArgumentException("You have to pass the point in the format \"lat,lon\"");
-        }
-
         String lat = cords[0];
         String lon = cords[1];
         return jerseyClient.

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourceOpenCageData.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourceOpenCageData.java
@@ -10,6 +10,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
 import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,13 +37,15 @@ public class ConverterResourceOpenCageData {
 
     @GET
     @Timed
-    public Response handle(@NotNull @QueryParam("q") String query,
-            @QueryParam("limit") @DefaultValue("5") int limit,
-            @QueryParam("locale") @DefaultValue("") String locale,
-            @QueryParam("countrycode") @DefaultValue("") String countrycode,
-            @QueryParam("bounds") @DefaultValue("") String bounds,
-            @QueryParam("nominatim") @DefaultValue("false") boolean nominatim,
-            @QueryParam("find_osm_id") @DefaultValue("true") boolean find_osm_id            
+    public Response handle(@QueryParam("q") @DefaultValue("") String query,
+                           @QueryParam("limit") @DefaultValue("5") int limit,
+                           @QueryParam("locale") @DefaultValue("") String locale,
+                           @QueryParam("countrycode") @DefaultValue("") String countrycode,
+                           @QueryParam("bounds") @DefaultValue("") String bounds,
+                           @QueryParam("nominatim") @DefaultValue("false") boolean nominatim,
+                           @QueryParam("find_osm_id") @DefaultValue("true") boolean find_osm_id,
+                           @QueryParam("reverse") @DefaultValue("false") boolean reverse,
+                           @QueryParam("point") @DefaultValue("false") String point
     ) {
         if (limit > 10) {
             limit = 10;
@@ -50,7 +53,7 @@ public class ConverterResourceOpenCageData {
 
         WebTarget target = jerseyClient.
                 target(url).
-                queryParam("q", query).
+                queryParam("q", reverse?point:query).
                 queryParam("key", key).
                 queryParam("limit", limit);
 

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourceOpenCageData.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourceOpenCageData.java
@@ -4,11 +4,9 @@ import com.codahale.metrics.annotation.Timed;
 import com.graphhopper.converter.api.OpenCageDataResponse;
 import com.graphhopper.converter.core.Converter;
 
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.time.StopWatch;
@@ -22,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 @Path("/opencagedata")
 @Produces("application/json; charset=utf-8")
-public class ConverterResourceOpenCageData {
+public class ConverterResourceOpenCageData extends AbstractConverterResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConverterResourceOpenCageData.class);
     private final String url;
@@ -47,9 +45,8 @@ public class ConverterResourceOpenCageData {
                            @QueryParam("reverse") @DefaultValue("false") boolean reverse,
                            @QueryParam("point") @DefaultValue("false") String point
     ) {
-        if (limit > 10) {
-            limit = 10;
-        }
+        limit = fixLimit(limit);
+        checkInvalidParameter(reverse,query,point);
 
         WebTarget target = jerseyClient.
                 target(url).


### PR DESCRIPTION
@karussell I added the changes from your annotations in this commit.

This PR adds the reverse geocoding from OCD. 

Should we add a check if the coordinates are given correct?
For example when you request this:
http://localhost:8080/opencagedata?point=41.3713072,2.1752074&reverse=true

Everything works as expected. If you remove the coma from the coordinates like this:
http://localhost:8080/opencagedata?point=41.37130722.1752074&reverse=true

You don't get an exception, but just an empty result. If you request the same for nominatim you get an exception, since we need to split the coordinates for a reverse geocoding request for nominatim. This is somewhat inconsistent. But not sure if we should something that's not necessary?
