### PR TITLE
Added more possible streetalike keys and some new keys

### DIFF
--- a/src/main/java/com/graphhopper/converter/api/AbstractAddress.java
+++ b/src/main/java/com/graphhopper/converter/api/AbstractAddress.java
@@ -1,0 +1,77 @@
+package com.graphhopper.converter.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Contains shared address data between Nominatim and OpencageData
+ *
+ * @author Robin Boldt
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class AbstractAddress {
+
+    @JsonProperty
+    public String country;
+    @JsonProperty
+    public String city;
+    @JsonProperty
+    public String state;
+    @JsonProperty
+    public String town;
+    @JsonProperty
+    public String village;
+    @JsonProperty
+    public String hamlet;
+    @JsonProperty("house_number")
+    public String houseNumber;
+    @JsonProperty
+    public String postcode;
+
+    // Possible Street names TODO: Not sure what tags can be returned here
+    @JsonProperty
+    public String road;
+    @JsonProperty
+    public String pedestrian;
+    @JsonProperty
+    public String path;
+    @JsonProperty
+    public String footway;
+    @JsonProperty
+    public String construction;
+    @JsonProperty
+    public String cycleway;
+
+    public String getGHCity() {
+        if (city != null) {
+            return city;
+        }
+        if (town != null) {
+            return town;
+        }
+        if (village != null) {
+            return village;
+        }
+        return hamlet;
+    }
+
+    public String getStreetName() {
+        if (road != null) {
+            return road;
+        }
+        if (pedestrian != null) {
+            return pedestrian;
+        }
+        if (path != null) {
+            return path;
+        }
+        if (footway != null) {
+            return footway;
+        }
+        if (cycleway != null) {
+            return cycleway;
+        }
+        return construction;
+    }
+
+}

--- a/src/main/java/com/graphhopper/converter/api/GHEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/GHEntry.java
@@ -24,7 +24,7 @@ public class GHEntry {
     private String postcode;
     private String osmValue;
 
-    public GHEntry(Long osmId, String type, double lat, double lng, String name, String country, String city, String state, String street, String houseNumber, String postcode, String osmValue) {
+    public GHEntry(Long osmId, String type, double lat, double lng, String name, String osmValue, String country, String city, String state, String street, String houseNumber, String postcode) {
         this.osmId = osmId;
         this.osmType = type;
         this.point = new Point(lat, lng);
@@ -36,6 +36,10 @@ public class GHEntry {
         this.houseNumber = houseNumber;
         this.postcode = postcode;
         this.osmValue = osmValue;
+    }
+
+    public GHEntry(Long osmId, String type, double lat, double lng, String name, String osmValue, AbstractAddress address) {
+        this(osmId, type, lat, lng, name, osmValue, address.country, address.getGHCity(), address.state, address.getStreetName(), address.houseNumber, address.postcode);
     }
 
     public GHEntry(){}

--- a/src/main/java/com/graphhopper/converter/api/GHEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/GHEntry.java
@@ -21,8 +21,10 @@ public class GHEntry {
     private String state;
     private String street;
     private String houseNumber;
+    private String postcode;
+    private String osmValue;
 
-    public GHEntry(Long osmId, String type, double lat, double lng, String name, String country, String city, String state, String street, String houseNumber) {
+    public GHEntry(Long osmId, String type, double lat, double lng, String name, String country, String city, String state, String street, String houseNumber, String postcode, String osmValue) {
         this.osmId = osmId;
         this.osmType = type;
         this.point = new Point(lat, lng);
@@ -32,6 +34,8 @@ public class GHEntry {
         this.state = state;
         this.street = street;
         this.houseNumber = houseNumber;
+        this.postcode = postcode;
+        this.osmValue = osmValue;
     }
 
     public GHEntry(){}
@@ -124,6 +128,26 @@ public class GHEntry {
     @JsonProperty("house_number")
     public void setHouseNumber(String houseNumber) {
         this.houseNumber = houseNumber;
+    }
+
+    @JsonProperty
+    public String getPostcode() {
+        return postcode;
+    }
+
+    @JsonProperty
+    public void setPostcode(String postcode) {
+        this.postcode = postcode;
+    }
+
+    @JsonProperty("osm_value")
+    public String getOsmValue() {
+        return osmValue;
+    }
+
+    @JsonProperty("osm_value")
+    public void setOsmValue(String osmValue) {
+        this.osmValue = osmValue;
     }
 
     public class Point {

--- a/src/main/java/com/graphhopper/converter/api/NominatimEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/NominatimEntry.java
@@ -18,10 +18,10 @@ public class NominatimEntry {
     private String displayName;
     private String classString;
 
-    // This is not the omsType
+    // This is not the omsType, but for example "restaurant" or "tertiary"
     private String type;
 
-    private Address address;
+    public Address address;
 
     public NominatimEntry(long osmId, String type, double lat, double lon, String displayName, String country, String city) {
         this.osmId = osmId;
@@ -37,22 +37,6 @@ public class NominatimEntry {
 
     public NominatimEntry() {
         this.address = new Address();
-    }
-
-    public String getStreetName() {
-        if (this.address.road != null) {
-            return this.address.road;
-        }
-        if (this.address.pedestrian != null) {
-            return this.address.pedestrian;
-        }
-        if (this.address.path != null) {
-            return this.address.path;
-        }
-        if (this.address.footway != null) {
-            return this.address.footway;
-        }
-        return this.address.construction;
     }
 
     @JsonProperty("osm_id")
@@ -143,51 +127,11 @@ public class NominatimEntry {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class Address {
+    public class Address extends AbstractAddress{
 
         public Address() {
         }
 
-        @JsonProperty
-        public String country;
-        @JsonProperty
-        public String city;
-        @JsonProperty
-        public String state;
-        @JsonProperty
-        public String town;
-        @JsonProperty
-        public String village;
-        @JsonProperty
-        public String hamlet;
-        @JsonProperty("house_number")
-        public String houseNumber;
-        @JsonProperty
-        public String postcode;
 
-        // Possible Street names TODO: Not sure what tags can be returned here
-        @JsonProperty
-        public String road;
-        @JsonProperty
-        public String pedestrian;
-        @JsonProperty
-        public String path;
-        @JsonProperty
-        public String footway;
-        @JsonProperty
-        public String construction;
-
-        public String getGHCity() {
-            if (city != null) {
-                return city;
-            }
-            if (town != null) {
-                return town;
-            }
-            if (village != null) {
-                return village;
-            }
-            return hamlet;
-        }
     }
 }

--- a/src/main/java/com/graphhopper/converter/api/NominatimEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/NominatimEntry.java
@@ -18,6 +18,9 @@ public class NominatimEntry {
     private String displayName;
     private String classString;
 
+    // This is not the omsType
+    private String type;
+
     private Address address;
 
     public NominatimEntry(long osmId, String type, double lat, double lon, String displayName, String country, String city) {
@@ -43,7 +46,13 @@ public class NominatimEntry {
         if (this.address.pedestrian != null) {
             return this.address.pedestrian;
         }
-        return null;
+        if (this.address.path != null) {
+            return this.address.path;
+        }
+        if (this.address.footway != null) {
+            return this.address.footway;
+        }
+        return this.address.construction;
     }
 
     @JsonProperty("osm_id")
@@ -123,6 +132,16 @@ public class NominatimEntry {
         this.classString = classString;
     }
 
+    @JsonProperty
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty
+    public void setType(String type) {
+        this.type = type;
+    }
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     public class Address {
 
@@ -141,12 +160,22 @@ public class NominatimEntry {
         public String village;
         @JsonProperty
         public String hamlet;
-        @JsonProperty("road")
-        public String road;
-        @JsonProperty("pedestrian")
-        public String pedestrian;
         @JsonProperty("house_number")
         public String houseNumber;
+        @JsonProperty
+        public String postcode;
+
+        // Possible Street names TODO: Not sure what tags can be returned here
+        @JsonProperty
+        public String road;
+        @JsonProperty
+        public String pedestrian;
+        @JsonProperty
+        public String path;
+        @JsonProperty
+        public String footway;
+        @JsonProperty
+        public String construction;
 
         public String getGHCity() {
             if (city != null) {

--- a/src/main/java/com/graphhopper/converter/api/OpenCageDataEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/OpenCageDataEntry.java
@@ -58,10 +58,6 @@ public class OpenCageDataEntry {
         public String country;
         @JsonProperty("country_code")
         public String countryCode;
-        @JsonProperty("road")
-        public String road;
-        @JsonProperty("pedestrian")
-        public String pedestrian;
         @JsonProperty("house_number")
         public String houseNumber;
         @JsonProperty("county")
@@ -77,6 +73,20 @@ public class OpenCageDataEntry {
         public String village;
         @JsonProperty("hamlet")
         public String hamlet;
+        @JsonProperty
+        public String postcode;
+
+        // Possible Street names TODO: Not sure what tags can be returned here
+        @JsonProperty
+        public String road;
+        @JsonProperty
+        public String pedestrian;
+        @JsonProperty
+        public String path;
+        @JsonProperty
+        public String footway;
+        @JsonProperty
+        public String construction;
 
         public String getGHCity() {
             if (city != null) {
@@ -90,6 +100,7 @@ public class OpenCageDataEntry {
             }
             return hamlet;
         }
+
     }
 
     public OpenCageDataEntry() {
@@ -110,7 +121,13 @@ public class OpenCageDataEntry {
         if (this.components.pedestrian != null) {
             return this.components.pedestrian;
         }
-        return null;
+        if (this.components.path != null) {
+            return this.components.path;
+        }
+        if (this.components.footway != null) {
+            return this.components.footway;
+        }
+        return this.components.construction;
     }
 
     @JsonProperty("formatted")

--- a/src/main/java/com/graphhopper/converter/api/OpenCageDataEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/OpenCageDataEntry.java
@@ -12,7 +12,7 @@ public class OpenCageDataEntry {
     private String formatted;
     private OCDAnnoations annotations;
     private OCDGeometry geometry;
-    private OCDComponents components;
+    public OCDComponents components;
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class OCDAnnoations {
@@ -47,60 +47,17 @@ public class OpenCageDataEntry {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class OCDComponents {
+    public static class OCDComponents extends AbstractAddress{
 
         public OCDComponents() {
         }
 
         @JsonProperty("_type")
         public String type;
-        @JsonProperty("country")
-        public String country;
         @JsonProperty("country_code")
         public String countryCode;
-        @JsonProperty("house_number")
-        public String houseNumber;
         @JsonProperty("county")
         public String county;
-        @JsonProperty("state")
-        public String state;
-
-        @JsonProperty("city")
-        public String city;
-        @JsonProperty("town")
-        public String town;
-        @JsonProperty("village")
-        public String village;
-        @JsonProperty("hamlet")
-        public String hamlet;
-        @JsonProperty
-        public String postcode;
-
-        // Possible Street names TODO: Not sure what tags can be returned here
-        @JsonProperty
-        public String road;
-        @JsonProperty
-        public String pedestrian;
-        @JsonProperty
-        public String path;
-        @JsonProperty
-        public String footway;
-        @JsonProperty
-        public String construction;
-
-        public String getGHCity() {
-            if (city != null) {
-                return city;
-            }
-            if (town != null) {
-                return town;
-            }
-            if (village != null) {
-                return village;
-            }
-            return hamlet;
-        }
-
     }
 
     public OpenCageDataEntry() {
@@ -112,22 +69,6 @@ public class OpenCageDataEntry {
         this.geometry.lat = lat;
         this.geometry.lng = lon;
         this.components = components;
-    }
-
-    public String getStreetName() {
-        if (this.components.road != null) {
-            return this.components.road;
-        }
-        if (this.components.pedestrian != null) {
-            return this.components.pedestrian;
-        }
-        if (this.components.path != null) {
-            return this.components.path;
-        }
-        if (this.components.footway != null) {
-            return this.components.footway;
-        }
-        return this.components.construction;
     }
 
     @JsonProperty("formatted")

--- a/src/main/java/com/graphhopper/converter/core/Converter.java
+++ b/src/main/java/com/graphhopper/converter/core/Converter.java
@@ -14,7 +14,7 @@ public class Converter {
     public static GHEntry convertFromNominatim(NominatimEntry response) {
         GHEntry rsp = new GHEntry(response.getOsmId(), response.getGHOsmType(), response.getLat(), response.getLon(),
                 response.getDisplayName(), response.getAddress().country, response.getAddress().getGHCity(),
-                response.getAddress().state, response.getStreetName(), response.getAddress().houseNumber,
+                response.getAddress().state, response.address.getStreetName(), response.getAddress().houseNumber,
                 response.getAddress().postcode, response.getType());
         return rsp;
     }
@@ -70,7 +70,7 @@ public class Converter {
 
         GHEntry rsp = new GHEntry(osmId, type, response.getGeometry().lat, response.getGeometry().lng,
                 response.getFormatted(), response.getComponents().country, response.getComponents().getGHCity(),
-                response.getComponents().state, response.getStreetName(), response.getComponents().houseNumber,
+                response.getComponents().state, response.components.getStreetName(), response.getComponents().houseNumber,
                 response.getComponents().postcode, response.getComponents().type);
 
         return rsp;

--- a/src/main/java/com/graphhopper/converter/core/Converter.java
+++ b/src/main/java/com/graphhopper/converter/core/Converter.java
@@ -12,8 +12,10 @@ import java.util.List;
 public class Converter {
 
     public static GHEntry convertFromNominatim(NominatimEntry response) {
-        GHEntry rsp = new GHEntry(response.getOsmId(), response.getGHOsmType(), response.getLat(), response.getLon(), response.getDisplayName(),
-                response.getAddress().country, response.getAddress().getGHCity(), response.getAddress().state, response.getStreetName(), response.getAddress().houseNumber);
+        GHEntry rsp = new GHEntry(response.getOsmId(), response.getGHOsmType(), response.getLat(), response.getLon(),
+                response.getDisplayName(), response.getAddress().country, response.getAddress().getGHCity(),
+                response.getAddress().state, response.getStreetName(), response.getAddress().houseNumber,
+                response.getAddress().postcode, response.getType());
         return rsp;
     }
 
@@ -24,7 +26,7 @@ public class Converter {
         }
 
         ghResponse.addCopyright("OpenStreetMap").addCopyright("GraphHopper");
-        if(!locale.isEmpty()){
+        if (!locale.isEmpty()) {
             ghResponse.setLocale(locale);
         }
         return createResponse(ghResponse, status);
@@ -68,7 +70,8 @@ public class Converter {
 
         GHEntry rsp = new GHEntry(osmId, type, response.getGeometry().lat, response.getGeometry().lng,
                 response.getFormatted(), response.getComponents().country, response.getComponents().getGHCity(),
-                response.getComponents().state, response.getStreetName(), response.getComponents().houseNumber);
+                response.getComponents().state, response.getStreetName(), response.getComponents().houseNumber,
+                response.getComponents().postcode, response.getComponents().type);
 
         return rsp;
     }
@@ -81,7 +84,7 @@ public class Converter {
         }
 
         ghResponse.addCopyright("OpenCageData").addCopyright("OpenStreetMap").addCopyright("GraphHopper");
-        if(!locale.isEmpty()){
+        if (!locale.isEmpty()) {
             ghResponse.setLocale(locale);
         }
         return createResponse(ghResponse, status);

--- a/src/main/java/com/graphhopper/converter/core/Converter.java
+++ b/src/main/java/com/graphhopper/converter/core/Converter.java
@@ -13,9 +13,7 @@ public class Converter {
 
     public static GHEntry convertFromNominatim(NominatimEntry response) {
         GHEntry rsp = new GHEntry(response.getOsmId(), response.getGHOsmType(), response.getLat(), response.getLon(),
-                response.getDisplayName(), response.getAddress().country, response.getAddress().getGHCity(),
-                response.getAddress().state, response.address.getStreetName(), response.getAddress().houseNumber,
-                response.getAddress().postcode, response.getType());
+                response.getDisplayName(), response.getType(), response.getAddress());
         return rsp;
     }
 
@@ -69,9 +67,7 @@ public class Converter {
         }
 
         GHEntry rsp = new GHEntry(osmId, type, response.getGeometry().lat, response.getGeometry().lng,
-                response.getFormatted(), response.getComponents().country, response.getComponents().getGHCity(),
-                response.getComponents().state, response.components.getStreetName(), response.getComponents().houseNumber,
-                response.getComponents().postcode, response.getComponents().type);
+                response.getFormatted(), response.getComponents().type, response.getComponents());
 
         return rsp;
     }


### PR DESCRIPTION
This PR intents to fix #23. 

I added the following keys **postcode** and **osm_value**. Also I added more possible street name keys. It seems that nominatim and opencagedata return a diverse set of streetname keys, not sure if there is a complete list of keys out there, it seems to be different from the osm highways tag.

I have not aded the osm_key as opencagedata seems to not return the osm_key, but I can add it for Nominatim?

@karussell Would you mind to have a look at my changes?