### PR TITLE
Better parameter validation of parameter point

### DIFF
--- a/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
+++ b/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
@@ -25,8 +25,17 @@ abstract class AbstractConverterResource {
             if (cords.length != 2) {
                 throw new BadRequestException("You have to pass the point in the format \"lat,lon\"");
             }
-            double lat = Double.parseDouble(cords[0]);
-            double lon = Double.parseDouble(cords[1]);
+            double lat;
+            double lon;
+            try {
+                lat = Double.parseDouble(cords[0]);
+                lon = Double.parseDouble(cords[1]);
+            } catch (RuntimeException e) {
+                throw new BadRequestException("The coordinates of point need to be valid numbers");
+            }
+            if (Double.isNaN(lat) || Double.isNaN(lon) || lat < -180 || lat > 180 || lon < -90 || lon > 90) {
+                throw new BadRequestException("The coordinates of point need to be valid coordinates");
+            }
         } else {
             if (query == null || query.isEmpty()) {
                 throw new BadRequestException("q cannot be empty");

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourceTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourceTest.java
@@ -124,4 +124,19 @@ public class ConverterResourceTest {
         GHResponse entry = response.readEntity(GHResponse.class);
         assertTrue(entry.getLocale().equals("en"));
     }
+
+    @Test
+    public void testIncorrectFormattedPoint() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("testIncorrectFormattedPoint");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        Response response = client.target(
+                String.format("http://localhost:%d/nominatim?reverse=true&point=NaN,NaN", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
 }


### PR DESCRIPTION
This fixes #26. This checks if the point parameter is a valid number, else an exception is thrown.