### PR TITLE
Check response code of geocoding provider

### DIFF
--- a/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
+++ b/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
@@ -1,6 +1,11 @@
 package com.graphhopper.converter.resources;
 
+import com.graphhopper.converter.api.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.client.WebTarget;
 import java.util.Locale;
 import java.util.MissingResourceException;
 
@@ -8,6 +13,8 @@ import java.util.MissingResourceException;
  * @author Robin Boldt
  */
 abstract class AbstractConverterResource {
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
 
     int fixLimit(int limit) {
         if (limit > 10) {
@@ -43,7 +50,7 @@ abstract class AbstractConverterResource {
         }
     }
 
-    String getLocaleFromParameter(String locale){
+    String getLocaleFromParameter(String locale) {
         Locale lo = Locale.forLanguageTag(locale);
         if (isValid(lo)) {
             return lo.toLanguageTag();
@@ -57,6 +64,14 @@ abstract class AbstractConverterResource {
             return locale.getISO3Language() != null && locale.getISO3Country() != null && !locale.toLanguageTag().equals("und");
         } catch (MissingResourceException e) {
             return false;
+        }
+    }
+
+    void failIfResponseNotSuccessful(WebTarget target, Status status) {
+        // TODO Maybe limit to == 200?
+        if (status.code < 200 || status.code >= 300) {
+            LOGGER.error("There was an issue with the target " + target.getUri() + " the provider returned: " + status.code + " - " + status.message);
+            throw new BadRequestException("The geocoding provider responded with an unexpected error. If this error happens again, please contact our support team support@graphhopper.com.");
         }
     }
 }

--- a/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
+++ b/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
@@ -71,7 +71,7 @@ abstract class AbstractConverterResource {
         // TODO Maybe limit to == 200?
         if (status.code < 200 || status.code >= 300) {
             LOGGER.error("There was an issue with the target " + target.getUri() + " the provider returned: " + status.code + " - " + status.message);
-            throw new BadRequestException("The geocoding provider responded with an unexpected error. If this error happens again, please contact our support team support@graphhopper.com.");
+            throw new BadRequestException("The geocoding provider responded with an unexpected error. Please contact our support team support@graphhopper.com.");
         }
     }
 }

--- a/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
+++ b/src/main/java/com/graphhopper/converter/resources/AbstractConverterResource.java
@@ -71,7 +71,7 @@ abstract class AbstractConverterResource {
         // TODO Maybe limit to == 200?
         if (status.code < 200 || status.code >= 300) {
             LOGGER.error("There was an issue with the target " + target.getUri() + " the provider returned: " + status.code + " - " + status.message);
-            throw new BadRequestException("The geocoding provider responded with an unexpected error. Please contact our support team support@graphhopper.com.");
+            throw new BadRequestException("The geocoding provider responded with an unexpected error.");
         }
     }
 }

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
@@ -75,8 +75,9 @@ public class ConverterResourceNominatim extends AbstractConverterResource {
 
         Response response = target.request().accept("application/json").
                 get();
-
         Status status = new Status(response.getStatus(), response.getStatusInfo().getReasonPhrase());
+        failIfResponseNotSuccessful(target, status);
+
         List<NominatimEntry> entitiesFromResponse;
         if (reverse) {
             entitiesFromResponse = new ArrayList<>(1);


### PR DESCRIPTION
Fixes #28.

We check the response code of the provider. If the response code is not equal to 2XX, we return a 400, with a generic exception message. We log the request as Error and ask the user to contact the support.

WDYT?