### PR TITLE
Add Pelias Endpoint

### DIFF
--- a/converter.yml
+++ b/converter.yml
@@ -7,6 +7,10 @@ openCageDataURL: https://api.opencagedata.com/geocode/v1/json
 openCageDataKey: ${OCD_KEY}
 openCageData: true
 
+peliasURL: ${PELIAS_URL}
+peliasKey: ${PELIAS_KEY}
+pelias: true
+
 gisgraphyGeocodingURL: ${GIS_GEO_URL}
 gisgraphyReverseGeocodingURL:  ${GIS_REV_GEO_URL}
 gisgraphySearchURL:  ${GIS_SEARCH_URL}

--- a/src/main/java/com/graphhopper/converter/ConverterApplication.java
+++ b/src/main/java/com/graphhopper/converter/ConverterApplication.java
@@ -6,6 +6,7 @@ import com.graphhopper.converter.resources.ConverterResourceGisgraphy;
 import com.graphhopper.converter.resources.ConverterResourceNominatim;
 import com.graphhopper.converter.resources.ConverterResourceOpenCageData;
 
+import com.graphhopper.converter.resources.ConverterResourcePelias;
 import io.dropwizard.Application;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -68,6 +69,12 @@ public class ConverterApplication extends Application<ConverterConfiguration> {
         if (converterConfiguration.isOpenCageData()) {
             final ConverterResourceOpenCageData resource = new ConverterResourceOpenCageData(
                     converterConfiguration.getOpenCageDataURL(), converterConfiguration.getOpenCageDataKey(), client);
+            environment.jersey().register(resource);
+        }
+
+        if (converterConfiguration.isPelias()) {
+            final ConverterResourcePelias resource = new ConverterResourcePelias(
+                    converterConfiguration.getPeliasURL(), converterConfiguration.getPeliasKey(), client);
             environment.jersey().register(resource);
         }
 

--- a/src/main/java/com/graphhopper/converter/ConverterConfiguration.java
+++ b/src/main/java/com/graphhopper/converter/ConverterConfiguration.java
@@ -22,6 +22,9 @@ public class ConverterConfiguration extends Configuration {
     private String openCageDataURL = "https://api.opencagedata.com/geocode/v1/json";
     private String openCageDataKey = "";
 
+    private String peliasURL = "";
+    private String peliasKey = "";
+
     private String gisgraphyGeocodingURL = "https://services.gisgraphy.com/geocoding/";
     private String gisgraphyReverseGeocodingURL ="https://services.gisgraphy.com/reversegeocoding/";
     private String gisgraphySearchURL =  "https://services.gisgraphy.com/fulltext/";
@@ -35,6 +38,7 @@ public class ConverterConfiguration extends Configuration {
     private boolean nominatim = true;
     private boolean gisgraphy = true;
     private boolean opencagedata;
+    private boolean pelias;
 
     private String ipBlackList = "";
     private String ipWhiteList = "";
@@ -97,6 +101,36 @@ public class ConverterConfiguration extends Configuration {
     @JsonProperty
     public void setOpenCageDataKey(String key) {
         this.openCageDataKey = key;
+    }
+
+    @JsonProperty
+    public void setPelias(boolean pelias) {
+        this.pelias = pelias;
+    }
+
+    @JsonProperty
+    public boolean isPelias() {
+        return this.pelias;
+    }
+
+    @JsonProperty
+    public String getPeliasURL() {
+        return peliasURL;
+    }
+
+    @JsonProperty
+    public void setPeliasURL(String url) {
+        this.peliasURL = url;
+    }
+
+    @JsonProperty
+    public String getPeliasKey() {
+        return peliasKey;
+    }
+
+    @JsonProperty
+    public void setPeliasKey(String key) {
+        this.peliasKey = key;
     }
 
     @JsonProperty

--- a/src/main/java/com/graphhopper/converter/api/PeliasEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/PeliasEntry.java
@@ -19,11 +19,11 @@ public class PeliasEntry {
         if (this.bbox == null || this.bbox.size() < 4)
             return null;
 
-        return new Extent(bbox.get(1), bbox.get(0), bbox.get(3), bbox.get(2));
+        return new Extent(bbox.get(3), bbox.get(0), bbox.get(1), bbox.get(2));
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class PeliasGeometry {
+    public static class PeliasGeometry {
 
         public List<Double> coordinates;
 
@@ -42,7 +42,7 @@ public class PeliasEntry {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class PeliasProperties {
+    public static class PeliasProperties {
 
         public String source;
         public String source_id;
@@ -81,7 +81,10 @@ public class PeliasEntry {
                 return null;
 
             // convert node into N, way into W and relation into R
-            return sourceArr[getId ? 1 : 0].toUpperCase().substring(0, 1);
+            if(getId)
+                return sourceArr[1];
+            else
+                return sourceArr[0].toUpperCase().substring(0, 1);
         }
 
     }

--- a/src/main/java/com/graphhopper/converter/api/PeliasEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/PeliasEntry.java
@@ -1,0 +1,90 @@
+package com.graphhopper.converter.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * @author Robin Boldt
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PeliasEntry {
+
+    public PeliasGeometry geometry;
+    public PeliasProperties properties;
+
+    public List<Double> bbox;
+
+    public Extent getExtent(){
+        if (this.bbox == null || this.bbox.size() < 4)
+            return null;
+
+        return new Extent(bbox.get(1), bbox.get(0), bbox.get(3), bbox.get(2));
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class PeliasGeometry {
+
+        public List<Double> coordinates;
+
+        public Double getLat() {
+            return ensureGeometryCapacity() ? this.coordinates.get(1) : null;
+        }
+
+        public Double getLon() {
+            return ensureGeometryCapacity() ? this.coordinates.get(0) : null;
+        }
+
+        //TODO This check might be dangerous if pelias returns other geometries than points?
+        private boolean ensureGeometryCapacity() {
+            return this.coordinates.size() == 2;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class PeliasProperties {
+
+        public String source;
+        public String source_id;
+
+        public String name;
+        public String country;
+        public String locality;
+        public String region;
+        public String macrocounty;
+        public String county;
+
+        public String postalcode;
+        public String street;
+        public String housenumber;
+
+        public String getGHOsmType() {
+            return getOSMInfo(false);
+        }
+
+        public Long getOsmId() {
+            String osmId = getOSMInfo(true);
+            if (osmId == null)
+                return null;
+            return Long.parseLong(osmId);
+        }
+
+        private String getOSMInfo(boolean getId) {
+            if (source == null || !source.equals("openstreetmap") || source_id == null) {
+                return null;
+            }
+
+            // source_id looks like "node/4153840591"
+            String[] sourceArr = source_id.split("/");
+
+            if (sourceArr.length != 2)
+                return null;
+
+            // convert node into N, way into W and relation into R
+            return sourceArr[getId ? 1 : 0].toUpperCase().substring(0, 1);
+        }
+
+    }
+
+}
+

--- a/src/main/java/com/graphhopper/converter/api/PeliasResponse.java
+++ b/src/main/java/com/graphhopper/converter/api/PeliasResponse.java
@@ -1,0 +1,19 @@
+package com.graphhopper.converter.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * @author Robin Boldt
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PeliasResponse {
+
+    public List<PeliasEntry> features;
+
+    @Override
+    public String toString() {
+        return "results:" + features.size();
+    }
+}

--- a/src/main/java/com/graphhopper/converter/core/Converter.java
+++ b/src/main/java/com/graphhopper/converter/core/Converter.java
@@ -3,7 +3,6 @@ package com.graphhopper.converter.core;
 import com.graphhopper.converter.api.*;
 
 import javax.ws.rs.core.Response;
-
 import java.util.HashMap;
 import java.util.List;
 
@@ -140,6 +139,29 @@ public class Converter {
         }
 
         ghResponse.addCopyright("OpenCageData")
+                .addCopyright("OpenStreetMap")
+                .addCopyright("GraphHopper");
+        if (!locale.isEmpty()) {
+            ghResponse.setLocale(locale);
+        }
+        return createResponse(ghResponse, status);
+    }
+
+    public static GHEntry convertFromPelias(PeliasEntry response) {
+        GHEntry rsp = new GHEntry(response.properties.getOsmId(), response.properties.getGHOsmType(), response.geometry.getLat(), response.geometry.getLon(),
+                response.properties.name, null, response.properties.country, response.properties.locality, response.properties.region, response.properties.macrocounty, response.properties.county, response.properties.street, response.properties.housenumber, response.properties.postalcode, response.getExtent());
+        return rsp;
+    }
+
+    public static Response convertFromPelias(PeliasResponse peliasRsp, Status status, String locale) {
+        List<PeliasEntry> peliasEntries = peliasRsp.features;
+        GHResponse ghResponse = new GHResponse(peliasEntries.size());
+        for (PeliasEntry peliasEntry : peliasEntries) {
+            ghResponse.add(convertFromPelias(peliasEntry));
+        }
+
+        ghResponse.addCopyright("geocode.earth")
+                .addCopyright("geocode.earth/guidelines")
                 .addCopyright("OpenStreetMap")
                 .addCopyright("GraphHopper");
         if (!locale.isEmpty()) {

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourcePelias.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourcePelias.java
@@ -1,0 +1,87 @@
+package com.graphhopper.converter.resources;
+
+import com.codahale.metrics.annotation.Timed;
+import com.graphhopper.converter.api.PeliasResponse;
+import com.graphhopper.converter.api.Status;
+import com.graphhopper.converter.core.Converter;
+
+import javax.ws.rs.*;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Robin Boldt
+ */
+@Path("/pelias")
+@Produces("application/json; charset=utf-8")
+public class ConverterResourcePelias extends AbstractConverterResource {
+
+    private final String url;
+    private final String key;
+    private final Client jerseyClient;
+
+    public ConverterResourcePelias(String url, String key, Client jerseyClient) {
+        this.url = url;
+        this.key = key;
+        this.jerseyClient = jerseyClient;
+    }
+
+    @GET
+    @Timed
+    public Response handle(@QueryParam("q") @DefaultValue("") String query,
+                           @QueryParam("limit") @DefaultValue("5") int limit,
+                           @QueryParam("locale") @DefaultValue("") String locale,
+                           @QueryParam("reverse") @DefaultValue("false") boolean reverse,
+                           @QueryParam("point") @DefaultValue("false") String point
+    ) {
+        limit = fixLimit(limit);
+        checkInvalidParameter(reverse, query, point);
+
+        WebTarget target;
+        if (reverse) {
+            target = buildReverseTarget(point);
+        } else {
+            target = buildForwardTarget(query);
+        }
+
+        target = target.
+                queryParam("size", limit).
+                queryParam("api_key", this.key);
+
+        if (!locale.isEmpty()) {
+            locale = getLocaleFromParameter(locale);
+            target = target.queryParam("lang", locale);
+        }
+
+        Response response = target.request().accept("application/json").get();
+        Status status = failIfResponseNotSuccessful(target, response);
+
+
+        try {
+            PeliasResponse peliasResponse = response.readEntity(PeliasResponse.class);
+            return Converter.convertFromPelias(peliasResponse, status, locale);
+        } catch (Exception e) {
+            LOGGER.error("There was an issue with the target " + target.getUri() + " the provider returned: " + status.code + " - " + status.message);
+            throw new BadRequestException("error deserializing geocoding feed");
+        } finally {
+            response.close();
+        }
+    }
+
+    private WebTarget buildForwardTarget(String query) {
+        return jerseyClient.
+                target(this.url + "search").
+                queryParam("text", query);
+    }
+
+    private WebTarget buildReverseTarget(String point) {
+        String[] cords = point.split(",");
+        String lat = cords[0];
+        String lon = cords[1];
+        return jerseyClient.
+                target(this.url + "reverse").
+                queryParam("point.lat", lat).
+                queryParam("point.lon", lon);
+    }
+}

--- a/src/test/java/com/graphhopper/converter/core/ConverterTest.java
+++ b/src/test/java/com/graphhopper/converter/core/ConverterTest.java
@@ -114,6 +114,34 @@ public class ConverterTest {
     }
 
     @Test
+    public void testPeliasonvert() {
+        PeliasEntry entry = new PeliasEntry();
+
+        entry.geometry = new PeliasEntry.PeliasGeometry();
+        entry.geometry.coordinates = Arrays.asList(new Double[]{-0.087652, 51.508096});
+
+        entry.properties = new PeliasEntry.PeliasProperties();
+        entry.properties.source = "openstreetmap";
+        entry.properties.source_id = "way/378493707";
+        entry.properties.country = "United Kingdom";
+        entry.properties.locality = "London";
+        entry.properties.macrocounty = "England";
+        entry.properties.name = "London Bridge";
+
+        entry.bbox = Arrays.asList(new Double[]{-0.0883452, 51.5067548, -0.0870196, 51.5092817,});
+
+        GHEntry ghEntry = Converter.convertFromPelias(entry);
+        assertEquals("London", ghEntry.getCity());
+        assertEquals(378493707, ghEntry.getOsmId(), .1);
+        Extent extent = ghEntry.getExtent();
+        assertEquals(-0.0883452, extent.getExtent().get(0), .000001);
+        assertEquals(51.5092817, extent.getExtent().get(1), .000001);
+        assertEquals( -0.0870196, extent.getExtent().get(2), .000001);
+        assertEquals(51.5067548, extent.getExtent().get(3), .000001);
+
+    }
+
+    @Test
     public void testGisgraphyWithCity() {
         GisgraphyAddressEntry city = new GisgraphyAddressEntry();
         city.setCity("Berlin");

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourcePeliasTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourcePeliasTest.java
@@ -1,0 +1,71 @@
+package com.graphhopper.converter.resource;
+
+import com.graphhopper.converter.ConverterApplication;
+import com.graphhopper.converter.ConverterConfiguration;
+import com.graphhopper.converter.api.GHResponse;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.glassfish.jersey.client.ClientProperties;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Robin Boldt
+ */
+public class ConverterResourcePeliasTest {
+    @ClassRule
+    public static final DropwizardAppRule<ConverterConfiguration> RULE =
+            new DropwizardAppRule<>(ConverterApplication.class, ResourceHelpers.resourceFilePath("converter.yml"));
+
+    @Test
+    public void testHandleForward() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test forward client");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        Response response = client.target(
+                String.format("http://localhost:%d/pelias?q=berlin", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        GHResponse entry = response.readEntity(GHResponse.class);
+        assertTrue(entry.getLocale().equals("en"));
+
+        // This might change in OSM and we might need to update this test then
+        List<Double> extent = entry.getHits().get(0).getExtent().getExtent();
+        assertEquals(13.1, extent.get(0), .1);
+        assertEquals(52.3, extent.get(1), .1);
+        assertEquals(13.7, extent.get(2), .1);
+        assertEquals(52.6, extent.get(3), .1);
+    }
+
+    @Test
+    public void testIssue50() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test issue 50");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        Response response = client.target(
+                String.format("http://localhost:%d/pelias?point=48.4882,2.6996&reverse=true", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        GHResponse entry = response.readEntity(GHResponse.class);
+
+        assertEquals("Seine-et-Marne", entry.getHits().get(0).getState());
+    }
+
+}

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourcePeliasTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourcePeliasTest.java
@@ -45,9 +45,9 @@ public class ConverterResourcePeliasTest {
         // This might change in OSM and we might need to update this test then
         List<Double> extent = entry.getHits().get(0).getExtent().getExtent();
         assertEquals(13.1, extent.get(0), .1);
-        assertEquals(52.3, extent.get(1), .1);
+        assertEquals(52.6, extent.get(1), .1);
         assertEquals(13.7, extent.get(2), .1);
-        assertEquals(52.6, extent.get(3), .1);
+        assertEquals(52.3, extent.get(3), .1);
     }
 
     @Test

--- a/src/test/resources/converter.yml
+++ b/src/test/resources/converter.yml
@@ -8,3 +8,7 @@ gisgraphyGeocodingURL: ${GIS_GEO_URL}
 gisgraphyReverseGeocodingURL:  ${GIS_REV_GEO_URL}
 gisgraphySearchURL:  ${GIS_SEARCH_URL}
 gisgraphyAPIKey: ${GIS_KEY}
+
+peliasURL: ${PELIAS_URL}
+peliasKey: ${PELIAS_KEY}
+pelias: true


### PR DESCRIPTION
This PR adds support for the Pelias endpoint.

This is a very basic implementation that does not consider some of the advanced features of pelias, like limiting results to a certain BBox or Circular area. 