### PR TITLE
Add Photon Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ NetToolKit does not return OSM tags (e.g. osm_id, osm_type, osm_value).
 }
 ```
 
+### Photon
+
+Photon offers the additional parameters:
+- `bbox`: Allows to filter for the results by a bbox using `minLon,minLat,maxLon,maxLat`, for example - `bbox=9.5,51.5,11.5,53.5`
+- `location_bias_scale`: You can define how strong the bias of the provided lat,lon is on the returned results. Range is 0.1 to 10, default is 1.6. 
+
 ## Starting the Server
 
 Run the following commands from the main directory - **the version of the .jar might be different**:
@@ -206,6 +212,5 @@ java -jar target/graphhopper-geocoder-converter-0.2-SNAPSHOT.jar server converte
 
 Click on `Run->Edit Configurations->+->Application`
 
-Main Class: `com.graphhopper.converter.ConverterApplication`
+Main Class: `com.graphhopper.converter.ConverterApplication`.
 Programm Arguments: `server converter.yml`
-Tick the `Single Instance Only` (not necessary, but recommended)

--- a/converter.yml
+++ b/converter.yml
@@ -21,6 +21,10 @@ gisgraphyReverseGeocodingURL:  ${GIS_REV_GEO_URL}
 gisgraphySearchURL:  ${GIS_SEARCH_URL}
 gisgraphyAPIKey: ${GIS_KEY}
 
+photonURL: https://photon.komoot.de/api/
+photonReverseURL: https://photon.komoot.de/reverse/
+photon: true
+
 # e.g. to restrict for local access
 # ipWhiteList:"localhost,127.0.0.1"
 ipWhiteList: ""

--- a/converter.yml
+++ b/converter.yml
@@ -20,6 +20,7 @@ gisgraphyGeocodingURL: ${GIS_GEO_URL}
 gisgraphyReverseGeocodingURL:  ${GIS_REV_GEO_URL}
 gisgraphySearchURL:  ${GIS_SEARCH_URL}
 gisgraphyAPIKey: ${GIS_KEY}
+gisgraphy: true
 
 photonURL: https://photon.komoot.de/api/
 photonReverseURL: https://photon.komoot.de/reverse/

--- a/src/main/java/com/graphhopper/converter/ConverterApplication.java
+++ b/src/main/java/com/graphhopper/converter/ConverterApplication.java
@@ -2,12 +2,9 @@ package com.graphhopper.converter;
 
 import com.graphhopper.converter.api.IPFilter;
 import com.graphhopper.converter.health.NominatimHealthCheck;
-import com.graphhopper.converter.resources.ConverterResourceGisgraphy;
-import com.graphhopper.converter.resources.ConverterResourceNominatim;
-import com.graphhopper.converter.resources.ConverterResourceOpenCageData;
-import com.graphhopper.converter.resources.ConverterResourceNetToolKit;
-import com.graphhopper.converter.resources.ConverterResourcePelias;
+import com.graphhopper.converter.resources.*;
 
+import com.graphhopper.converter.resources.ConverterResourceNetToolKit;
 import io.dropwizard.Application;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -90,6 +87,14 @@ public class ConverterApplication extends Application<ConverterConfiguration> {
                     converterConfiguration.getNetToolKitGeocodingURL(),
                     converterConfiguration.getNetToolKitReverseGeocodingURL(),
                     converterConfiguration.getNetToolKitKey(),
+                    client);
+            environment.jersey().register(resource);
+        }
+
+        if (converterConfiguration.isPhoton()) {
+            final ConverterResourcePhoton resource = new ConverterResourcePhoton(
+                    converterConfiguration.getPhotonURL(),
+                    converterConfiguration.getPhotonReverseURL(),
                     client);
             environment.jersey().register(resource);
         }

--- a/src/main/java/com/graphhopper/converter/ConverterConfiguration.java
+++ b/src/main/java/com/graphhopper/converter/ConverterConfiguration.java
@@ -46,8 +46,8 @@ public class ConverterConfiguration extends Configuration {
     private boolean healthCheck = true;
     private boolean nominatim = true;
     private boolean gisgraphy = true;
-    private boolean opencagedata;
-    private boolean pelias;
+    private boolean opencagedata = true;
+    private boolean pelias = true;
     private boolean nettoolkit = true;
     private boolean photon = true;
 

--- a/src/main/java/com/graphhopper/converter/ConverterConfiguration.java
+++ b/src/main/java/com/graphhopper/converter/ConverterConfiguration.java
@@ -34,6 +34,11 @@ public class ConverterConfiguration extends Configuration {
     private String netToolKitReverseGeocodingURL = "https://api.nettoolkit.com/v1/geo/reverse-geocodes?";
     private String netToolKitKey = "";
 
+    @NotEmpty
+    private String photonURL = "https://photon.komoot.de/api/";
+    @NotEmpty
+    private String photonReverseURL = "https://photon.komoot.de/reverse/";
+
     @Valid
     @NotNull
     private final JerseyClientConfiguration jerseyClient = new JerseyClientConfiguration();
@@ -44,6 +49,7 @@ public class ConverterConfiguration extends Configuration {
     private boolean opencagedata;
     private boolean pelias;
     private boolean nettoolkit = true;
+    private boolean photon = true;
 
     private String ipBlackList = "";
     private String ipWhiteList = "";
@@ -272,5 +278,35 @@ public class ConverterConfiguration extends Configuration {
     @JsonProperty
     public void setNetToolKit(boolean nettoolkit) {
         this.nettoolkit = nettoolkit;
+    }
+
+    @JsonProperty
+    public String getPhotonURL() {
+        return photonURL;
+    }
+
+    @JsonProperty
+    public void setPhotonURL(String photonURL) {
+        this.photonURL = photonURL;
+    }
+
+    @JsonProperty
+    public String getPhotonReverseURL() {
+        return photonReverseURL;
+    }
+
+    @JsonProperty
+    public void setPhotonReverseURL(String photonReverseURL) {
+        this.photonReverseURL = photonReverseURL;
+    }
+
+    @JsonProperty
+    public boolean isPhoton() {
+        return photon;
+    }
+
+    @JsonProperty
+    public void setPhoton(boolean photon) {
+        this.photon = photon;
     }
 }

--- a/src/main/java/com/graphhopper/converter/api/GeojsonPoint.java
+++ b/src/main/java/com/graphhopper/converter/api/GeojsonPoint.java
@@ -1,0 +1,33 @@
+package com.graphhopper.converter.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * @author Robin Boldt
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GeojsonPoint {
+
+    @JsonProperty("coordinates")
+    public List<Double> coordinates;
+
+    @JsonProperty("type")
+    public String type;
+
+    public Double getLat() {
+        return ensureGeometryCapacity() ? this.coordinates.get(1) : null;
+    }
+
+    public Double getLon() {
+        return ensureGeometryCapacity() ? this.coordinates.get(0) : null;
+    }
+
+    private boolean ensureGeometryCapacity() {
+        return this.coordinates.size() == 2 && type.equals("Point");
+    }
+
+}
+

--- a/src/main/java/com/graphhopper/converter/api/PhotonEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/PhotonEntry.java
@@ -18,10 +18,10 @@ public class PhotonEntry {
     public String type;
 
     @JsonProperty("properties")
-    public PeliasProperties properties;
+    public PhotonProperties properties;
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class PeliasProperties {
+    public static class PhotonProperties {
 
         @JsonProperty("osm_id")
         public long osmId;

--- a/src/main/java/com/graphhopper/converter/api/PhotonEntry.java
+++ b/src/main/java/com/graphhopper/converter/api/PhotonEntry.java
@@ -1,0 +1,70 @@
+package com.graphhopper.converter.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * @author Robin Boldt
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PhotonEntry {
+
+    @JsonProperty("geometry")
+    public GeojsonPoint geometry;
+
+    @JsonProperty("type")
+    public String type;
+
+    @JsonProperty("properties")
+    public PeliasProperties properties;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PeliasProperties {
+
+        @JsonProperty("osm_id")
+        public long osmId;
+
+        @JsonProperty("osm_type")
+        public String osmType;
+
+        @JsonProperty("name")
+        public String name;
+
+        @JsonProperty("osm_key")
+        public String osmKey;
+
+        @JsonProperty("osm_value")
+        public String osmValue;
+
+        @JsonProperty("country")
+        public String country;
+
+        @JsonProperty("state")
+        public String state;
+
+        @JsonProperty("city")
+        public String city;
+
+        @JsonProperty("street")
+        public String street;
+
+        @JsonProperty("housenumber")
+        public String housenumber;
+
+        @JsonProperty("postcode")
+        public String postcode;
+
+        @JsonProperty("extent")
+        List<Double> extent;
+
+        public Extent getExtent() {
+            if (this.extent == null || this.extent.size() != 4)
+                return null;
+
+            return new Extent(extent.get(3), extent.get(0), extent.get(1), extent.get(2));
+        }
+    }
+
+}

--- a/src/main/java/com/graphhopper/converter/api/PhotonResponse.java
+++ b/src/main/java/com/graphhopper/converter/api/PhotonResponse.java
@@ -1,0 +1,21 @@
+package com.graphhopper.converter.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * @author Robin Boldt
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PhotonResponse {
+
+    @JsonProperty("features")
+    public List<PhotonEntry> features;
+
+    @Override
+    public String toString() {
+        return "results:" + features.size();
+    }
+}

--- a/src/main/java/com/graphhopper/converter/core/Converter.java
+++ b/src/main/java/com/graphhopper/converter/core/Converter.java
@@ -198,6 +198,27 @@ public class Converter {
         return createResponse(ghResponse, status);
     }
 
+    public static GHEntry convertFromPhoton(PhotonEntry response) {
+        GHEntry rsp = new GHEntry(response.properties.osmId, response.properties.osmType, response.geometry.getLat(), response.geometry.getLon(),
+                response.properties.name, response.properties.osmValue, response.properties.country, response.properties.city, response.properties.state, null, null, response.properties.street, response.properties.housenumber, response.properties.postcode, response.properties.getExtent());
+        return rsp;
+    }
+
+    public static Response convertFromPhoton(PhotonResponse photonResponse, Status status, String locale) {
+        List<PhotonEntry> photonEntries = photonResponse.features;
+        GHResponse ghResponse = new GHResponse(photonEntries.size());
+        for (PhotonEntry photonEntry : photonEntries) {
+            ghResponse.add(convertFromPhoton(photonEntry));
+        }
+
+        ghResponse.addCopyright("OpenStreetMap")
+                .addCopyright("GraphHopper");
+        if (!locale.isEmpty()) {
+            ghResponse.setLocale(locale);
+        }
+        return createResponse(ghResponse, status);
+    }
+
     public static Response createResponse(GHResponse ghResponse, Status status) {
         if (status.code == 200) {
 

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourceNominatim.java
@@ -41,7 +41,7 @@ public class ConverterResourceNominatim extends AbstractConverterResource {
                            @QueryParam("viewboxlbrt") @DefaultValue("") String viewboxlbrt,
                            @QueryParam("bounded") @DefaultValue("") String bounded,
                            @QueryParam("reverse") @DefaultValue("false") boolean reverse,
-                           @QueryParam("point") @DefaultValue("false") String point
+                           @QueryParam("point") @DefaultValue("") String point
     ) {
         limit = fixLimit(limit);
         checkInvalidParameter(reverse, query, point);

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourceOpenCageData.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourceOpenCageData.java
@@ -40,7 +40,7 @@ public class ConverterResourceOpenCageData extends AbstractConverterResource {
                            @QueryParam("nominatim") @DefaultValue("false") boolean nominatim,
                            @QueryParam("find_osm_id") @DefaultValue("true") boolean find_osm_id,
                            @QueryParam("reverse") @DefaultValue("false") boolean reverse,
-                           @QueryParam("point") @DefaultValue("false") String point
+                           @QueryParam("point") @DefaultValue("") String point
     ) {
         limit = fixLimit(limit);
         checkInvalidParameter(reverse, query, point);

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourcePhoton.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourcePhoton.java
@@ -1,7 +1,7 @@
 package com.graphhopper.converter.resources;
 
 import com.codahale.metrics.annotation.Timed;
-import com.graphhopper.converter.api.PeliasResponse;
+import com.graphhopper.converter.api.PhotonResponse;
 import com.graphhopper.converter.api.Status;
 import com.graphhopper.converter.core.Converter;
 
@@ -13,17 +13,17 @@ import javax.ws.rs.core.Response;
 /**
  * @author Robin Boldt
  */
-@Path("/pelias")
+@Path("/photon")
 @Produces("application/json; charset=utf-8")
-public class ConverterResourcePelias extends AbstractConverterResource {
+public class ConverterResourcePhoton extends AbstractConverterResource {
 
-    private final String url;
-    private final String key;
+    private final String photonUrl;
+    private final String photonReverseUrl;
     private final Client jerseyClient;
 
-    public ConverterResourcePelias(String url, String key, Client jerseyClient) {
-        this.url = url;
-        this.key = key;
+    public ConverterResourcePhoton(String photonUrl, String photonReverseUrl, Client jerseyClient) {
+        this.photonUrl = photonUrl;
+        this.photonReverseUrl = photonReverseUrl;
         this.jerseyClient = jerseyClient;
     }
 
@@ -32,6 +32,8 @@ public class ConverterResourcePelias extends AbstractConverterResource {
     public Response handle(@QueryParam("q") @DefaultValue("") String query,
                            @QueryParam("limit") @DefaultValue("5") int limit,
                            @QueryParam("locale") @DefaultValue("") String locale,
+                           @QueryParam("bbox") @DefaultValue("") String bbox,
+                           @QueryParam("location_bias_scale") @DefaultValue("") String locationBiasScale,
                            @QueryParam("reverse") @DefaultValue("false") boolean reverse,
                            @QueryParam("point") @DefaultValue("") String point
     ) {
@@ -46,22 +48,35 @@ public class ConverterResourcePelias extends AbstractConverterResource {
         }
 
         target = target.
-                queryParam("size", limit).
-                queryParam("api_key", this.key);
+                queryParam("limit", limit);
+
+        if (!point.isEmpty()) {
+            String[] cords = point.split(",");
+            String lat = cords[0];
+            String lon = cords[1];
+            target = target.queryParam("lat", lat).
+                    queryParam("lon", lon);
+        }
 
         if (!locale.isEmpty()) {
             locale = getLocaleFromParameter(locale);
             target = target.queryParam("lang", locale);
         }
+        if (!bbox.isEmpty()) {
+            target = target.queryParam("bbox", bbox);
+        }
+        if (!locationBiasScale.isEmpty()) {
+            target = target.queryParam("location_bias_scale", locationBiasScale);
+        }
 
         Response response = target.request().accept("application/json").get();
         Status status = failIfResponseNotSuccessful(target, response);
 
-
         try {
-            PeliasResponse peliasResponse = response.readEntity(PeliasResponse.class);
-            return Converter.convertFromPelias(peliasResponse, status, locale);
+            PhotonResponse photonResponse = response.readEntity(PhotonResponse.class);
+            return Converter.convertFromPhoton(photonResponse, status, locale);
         } catch (Exception e) {
+            e.printStackTrace();
             LOGGER.error("There was an issue with the target " + target.getUri() + " the provider returned: " + status.code + " - " + status.message);
             throw new BadRequestException("error deserializing geocoding feed");
         } finally {
@@ -71,17 +86,12 @@ public class ConverterResourcePelias extends AbstractConverterResource {
 
     private WebTarget buildForwardTarget(String query) {
         return jerseyClient.
-                target(this.url + "search").
-                queryParam("text", query);
+                target(photonUrl).
+                queryParam("q", query);
     }
 
     private WebTarget buildReverseTarget(String point) {
-        String[] cords = point.split(",");
-        String lat = cords[0];
-        String lon = cords[1];
         return jerseyClient.
-                target(this.url + "reverse").
-                queryParam("point.lat", lat).
-                queryParam("point.lon", lon);
+                target(photonReverseUrl);
     }
 }

--- a/src/main/java/com/graphhopper/converter/resources/ConverterResourcePhoton.java
+++ b/src/main/java/com/graphhopper/converter/resources/ConverterResourcePhoton.java
@@ -76,7 +76,6 @@ public class ConverterResourcePhoton extends AbstractConverterResource {
             PhotonResponse photonResponse = response.readEntity(PhotonResponse.class);
             return Converter.convertFromPhoton(photonResponse, status, locale);
         } catch (Exception e) {
-            e.printStackTrace();
             LOGGER.error("There was an issue with the target " + target.getUri() + " the provider returned: " + status.code + " - " + status.message);
             throw new BadRequestException("error deserializing geocoding feed");
         } finally {

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourceNominatimTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourceNominatimTest.java
@@ -45,9 +45,9 @@ public class ConverterResourceNominatimTest {
 
         // This might change in OSM and we might need to update this test then
         List<Double> extent = entry.getHits().get(0).getExtent().getExtent();
-        assertEquals(extent.get(0), 13.2, .1);
+        assertEquals(extent.get(0), 13.1, .1);
         assertEquals(extent.get(1), 52.3, .1);
-        assertEquals(extent.get(2), 13.5, .1);
+        assertEquals(extent.get(2), 13.7, .1);
         assertEquals(extent.get(3), 52.6, .1);
     }
 

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourceNominatimTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourceNominatimTest.java
@@ -45,10 +45,10 @@ public class ConverterResourceNominatimTest {
 
         // This might change in OSM and we might need to update this test then
         List<Double> extent = entry.getHits().get(0).getExtent().getExtent();
-        assertEquals(extent.get(0), 13.1, .1);
-        assertEquals(extent.get(1), 52.3, .1);
-        assertEquals(extent.get(2), 13.7, .1);
-        assertEquals(extent.get(3), 52.6, .1);
+        assertEquals(13.09, extent.get(0), .1);
+        assertEquals(52.33, extent.get(1), .1);
+        assertEquals(13.76, extent.get(2), .1);
+        assertEquals(52.52, extent.get(3), .1);
     }
 
     @Test

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourceNominatimTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourceNominatimTest.java
@@ -48,7 +48,7 @@ public class ConverterResourceNominatimTest {
         assertEquals(13.09, extent.get(0), .1);
         assertEquals(52.33, extent.get(1), .1);
         assertEquals(13.76, extent.get(2), .1);
-        assertEquals(52.52, extent.get(3), .1);
+        assertEquals(52.68, extent.get(3), .1);
     }
 
     @Test

--- a/src/test/java/com/graphhopper/converter/resource/ConverterResourcePhotonTest.java
+++ b/src/test/java/com/graphhopper/converter/resource/ConverterResourcePhotonTest.java
@@ -1,0 +1,134 @@
+package com.graphhopper.converter.resource;
+
+import com.graphhopper.converter.ConverterApplication;
+import com.graphhopper.converter.ConverterConfiguration;
+import com.graphhopper.converter.api.GHResponse;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.glassfish.jersey.client.ClientProperties;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Robin Boldt
+ */
+public class ConverterResourcePhotonTest {
+    @ClassRule
+    public static final DropwizardAppRule<ConverterConfiguration> RULE =
+            new DropwizardAppRule<>(ConverterApplication.class, ResourceHelpers.resourceFilePath("converter.yml"));
+
+    @Test
+    public void testHandleForward() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test forward client");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        Response response = client.target(
+                String.format("http://localhost:%d/photon?q=berlin", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        GHResponse entry = response.readEntity(GHResponse.class);
+        assertTrue(entry.getLocale().equals("en"));
+
+        // This might change in OSM and we might need to update this test then
+        List<Double> extent = entry.getHits().get(1).getExtent().getExtent();
+        assertEquals(extent.get(0), 13.1, .1);
+        assertEquals(extent.get(1), 52.3, .1);
+        assertEquals(extent.get(2), 13.7, .1);
+        assertEquals(extent.get(3), 52.6, .1);
+    }
+
+    @Test
+    public void testLocationBiasScale() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test location bias scale");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        // First test a low bias
+        Response response = client.target(
+                String.format("http://localhost:%d/photon?q=beer&point=48.774675,9.172136&location_bias_scale=0.1", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        GHResponse entry = response.readEntity(GHResponse.class);
+        assertEquals("Beer Sheva", entry.getHits().get(0).getName());
+
+        // Now test a high bias
+        response = client.target(
+                String.format("http://localhost:%d/photon?q=beer&point=48.774675,9.172136&location_bias_scale=10", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        entry = response.readEntity(GHResponse.class);
+        assertEquals("Georg-Beer-Weg", entry.getHits().get(0).getName());
+    }
+
+    @Test
+    public void testBBox() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test bbox");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        Response response = client.target(
+                String.format("http://localhost:%d/photon?q=berlin&bbox=9.5,51.5,11.5,53.5&locale=de", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        GHResponse entry = response.readEntity(GHResponse.class);
+        assertEquals("Niedersachsen", entry.getHits().get(0).getState());
+    }
+
+    @Test
+    public void testHandleReverse() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test reverse client");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        Response response = client.target(
+                String.format("http://localhost:%d/photon?point=48.774675,9.172136&reverse=true", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        GHResponse entry = response.readEntity(GHResponse.class);
+        assertEquals("Rotebühlplatz", entry.getHits().get(0).getName());
+        assertEquals("Baden-Württemberg", entry.getHits().get(0).getState());
+    }
+
+    @Test
+    public void testCorrectLocale() {
+        Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("testCorrectLocale");
+
+        client.property(ClientProperties.CONNECT_TIMEOUT, 100000);
+        client.property(ClientProperties.READ_TIMEOUT, 100000);
+
+        Response response = client.target(
+                String.format("http://localhost:%d/photon?q=berlin&locale=de", RULE.getLocalPort()))
+                .request()
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        GHResponse entry = response.readEntity(GHResponse.class);
+        assertTrue(entry.getLocale().equals("de"));
+    }
+
+}


### PR DESCRIPTION
Fixes #61.

This PR adds the Photon Endpoint to the geocoding converter. If we want to use this as the default, we should probably add a few more tests? Overall, the integration felt quite good, since Photon is pretty similar to the GH format.

Not sure if I missed a parameter or maybe a response object?